### PR TITLE
ENH: Build with `meson`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,55 @@
+project('pypotlib', ['c', 'fortran'],
+       version: '0.0.13',
+  default_options : ['warning_level=2', 'cpp_std=c++17'])
+# IMPORTANT!! warning_level=3 passes -fimplicit-none
+# Many of the older Fortran codes need implicit typing
+
+_args = [] # Extra arguments
+_deps = [] # Dependencies
+
+# ---------------------- Dependencies
+_deps += dependency('lapack')
+
+# Languages
+cc = meson.get_compiler('c')
+
+# ---------------------- Library
+
+gjplib = library('GaussJacobiQaud',
+              sources: [
+                'src/gjp_constants.f90',
+                'src/gjp_types.f90',
+                'src/gjp_lapack.f90',
+                'src/gjp_rec.f90',
+                'src/gjp_gw.f90',
+                'src/GaussJacobiQuad.f90',
+              ],
+              dependencies: _deps,
+              install: true,
+)
+
+# ---------------------- Applications
+
+gjp_quad = executable('gjp_quad',
+                      sources: [
+                        'app/gjp_quad.f90',
+                      ],
+                      link_with: [gjplib],
+                      install: true,
+)
+
+gjp_quad_rec = executable('gjp_quad_rec',
+                      sources: [
+                        'app/gjp_quad_rec.f90',
+                      ],
+                      link_with: [gjplib],
+                      install: true,
+)
+
+gjp_quad_gw = executable('gjp_quad_gw',
+                      sources: [
+                        'app/gjp_quad_gw.f90',
+                      ],
+                      link_with: [gjplib],
+                      install: true,
+)

--- a/readme.org
+++ b/readme.org
@@ -23,6 +23,15 @@ fpm run gjp_quad -- <npoints> <alpha> <beta> <method>
 
 Currently the only supported methods are "recurrence" and "gw" (Golub Welsch).
 
+*** Meson Support
+A ~meson~ build backend is also present, which makes it easier to incorporate as subprojects of projects other than those supported by ~fpm~.
+
+#+begin_src bash
+meson setup bbdir
+meson compile -C bbdir
+./bbdir/gjp_quad <npoints> <alpha> <beta> <method>
+#+end_src
+
 ** Notes
 The ~recurrence~ method fails for high values of ~beta~ so the ~gw~ method
 should be used in such situations.


### PR DESCRIPTION
I like `meson`. Makes it easier to swap libraries too, might add more options later.